### PR TITLE
Add responsive compatibility for small legacy phones (iphone5)

### DIFF
--- a/frontend/css/responsive.css
+++ b/frontend/css/responsive.css
@@ -152,7 +152,9 @@ h3.panel-title {
 	padding-bottom: 0px;
 }
 h1#logo {
-	margin-left: 25px;
+	margin-left: 10px;
+	background-size: 164px 63px;
+	top: -6px;
 }
 header #eos-price-usd {
 	right: 30px;
@@ -167,5 +169,18 @@ header #eos-price-usd {
 }
 #sourcecode {
 	left: 0px;
+}
+h3 {
+	font-size: 23px;
+}
+h4 {
+	font-size: 20px;
+}
+}
+
+/*Legacy extra-small devices (old phones):*/
+@media only screen and (max-width: 365px) {
+header #eos-price-usd {
+	top: 72px;
 }
 }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -438,7 +438,7 @@ h1#logo {
 	margin: 0;
 	display: block;
 	margin-left: 35px;
-	top: -2px;
+	top: -3px;
 	float: left;
 }
 h1#logo a {


### PR DESCRIPTION
- Updated responsive CSS to accomodate legacy devices with extra-small screen widths of <365px (ex: iphone5, galaxy s5)
- Fix overlap in EOS/USD price with EOS New York logo in header on iphone6/7/8 resolution
- Fix font sizes to fit better on screen for iphone 6/7/8 resolution